### PR TITLE
OTA files for master stream

### DIFF
--- a/firmware/master/1.1.0.1889.ota
+++ b/firmware/master/1.1.0.1889.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0674fd69c5f686e4caace97bb5ac1e3fb7649db03612797f3cbfdc6eed374446
+size 183869440

--- a/firmware/master/1.1.0.1933.ota
+++ b/firmware/master/1.1.0.1933.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ce0adee32ba52979bdce7398e25f53812e38775f4f2cc870fc15ceeba811cad
+size 184320000

--- a/firmware/master/1.1.0.1944.ota
+++ b/firmware/master/1.1.0.1944.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d9c382208cc0269316117dc5f8bf2187c1f2b17cfeba5d8ac4fa5e10a47803c
+size 185763840

--- a/firmware/master/1.1.0.1951.ota
+++ b/firmware/master/1.1.0.1951.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82cba0efbf3d13ea25e34066aaaf90b5c51bc82f9ed05dc6b68dec4cfea99652
+size 186009600

--- a/firmware/master/1.1.0.1961.ota
+++ b/firmware/master/1.1.0.1961.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40b8c4d02488a4984d4d7d294e3feaea468c3dc303930a57140d45183537404c
+size 180858880

--- a/firmware/master/1.1.0.1963.ota
+++ b/firmware/master/1.1.0.1963.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87c9f3b9d9a0e7d54c7e735199a875e7602a622e87ce9834df986a514e372648
+size 180858880

--- a/firmware/master/1.1.0.1991.ota
+++ b/firmware/master/1.1.0.1991.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5a47c48fcfa04b16143bb19ffddf205d0104b1692357a913ecdedecfe647ea3
+size 192133120

--- a/firmware/master/1.1.0.1996.ota
+++ b/firmware/master/1.1.0.1996.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:324b191553fb7edc037933a0dc72bb0668ad9a6e55456f9b39f9e0b783dd2b41
+size 192163840

--- a/firmware/master/1.1.0.2001.ota
+++ b/firmware/master/1.1.0.2001.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c4e00b641bdeedb67a3605282ed9ba37f72fdadc63883b5fa196fccc3b66c53
+size 192235520

--- a/firmware/master/1.1.0.2005.ota
+++ b/firmware/master/1.1.0.2005.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baa211cb3a665afaf8c08af5f99585006dcd9c3eef3f29352d8d0e57a5c26b56
+size 192399360

--- a/firmware/master/1.1.0.2010.ota
+++ b/firmware/master/1.1.0.2010.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1587264274f9df7e636ea179f97c9ff924f0c5b7fc98d379cefbfe2a76642050
+size 192409600

--- a/firmware/master/1.2.0.2037.ota
+++ b/firmware/master/1.2.0.2037.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c5f8531df050788a1e45cbcbc0343d4566ad19ba12288def9884b1e5e0b4588
+size 199249920

--- a/firmware/master/1.2.0.2202.ota
+++ b/firmware/master/1.2.0.2202.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a0e926d105e81edeefbf23f052f0ad79d84dd164bd733fddb1568d22492c678
+size 199290880

--- a/firmware/master/1.2.0.2209.ota
+++ b/firmware/master/1.2.0.2209.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba0dfe5e9f4a394e7fdfb5022070e2e9fcc40e3a35d53f15268106129f86949
+size 199680000

--- a/firmware/master/1.2.1.2213.ota
+++ b/firmware/master/1.2.1.2213.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0ac43b4cec3833e1f5e45f348eff4785b69a15e47583fc8e66be5e7fcd24bba
+size 200826880

--- a/firmware/master/1.2.1.2227.ota
+++ b/firmware/master/1.2.1.2227.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58ebb412241c35fa47a08dc7a8fd7145b4a4b28ab8140a1524846546144c3cbc
+size 196802560

--- a/firmware/master/1.2.1.2233.ota
+++ b/firmware/master/1.2.1.2233.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a83c84d10ae141ee0527c681cd4ba00b085b0475c50e95caa5d8c396347cc92
+size 189214720

--- a/firmware/master/1.2.1.2239.ota
+++ b/firmware/master/1.2.1.2239.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23cce54c3b13b4498e64bad09f46ad83216977fc4dfba6112274b7cc21165634
+size 189245440

--- a/firmware/master/1.2.1.2245.ota
+++ b/firmware/master/1.2.1.2245.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ed329ab292523d26d8f5d8c8ddda7549d405394f4db35233140dc89a23d8341
+size 189306880

--- a/firmware/master/1.2.1.2250.ota
+++ b/firmware/master/1.2.1.2250.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d81c537db1620971f57e4ed65e7e6655efd5d59db158a1cb1dd8b83caccddb2f
+size 189337600

--- a/firmware/master/1.2.1.2263.ota
+++ b/firmware/master/1.2.1.2263.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ba769897aca1c60e1ca410bc3bd2f855c0134ee939417ff2f0e20d89a7a8c14
+size 188692480

--- a/firmware/master/1.2.1.2264.ota
+++ b/firmware/master/1.2.1.2264.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a9a7b7baa315901cc5a8e2296a7ffb2884c307e5734eca5a287a38390141998
+size 188692480

--- a/firmware/master/1.2.1.2265.ota
+++ b/firmware/master/1.2.1.2265.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e63c1bd7986ea0967e547ea3bb5b65199329decc52a85990dab021a5f50b9b18
+size 188692480

--- a/firmware/master/1.2.1.2272.ota
+++ b/firmware/master/1.2.1.2272.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159fb94b3c68420e8104bcc44ec485ca2e0596976f340cebaef96aca1a050829
+size 189265920

--- a/firmware/master/1.2.1.2283.ota
+++ b/firmware/master/1.2.1.2283.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38a39dc19870eb97dd68b3ea6aec0da11f1bc1668f7c89b9a93230d418e5b71c
+size 190085120

--- a/firmware/master/1.2.1.2291.ota
+++ b/firmware/master/1.2.1.2291.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4aa3b8dfabce8bbde1cf93ee045cb3fa9b79c2e4f65fe5395e54f0353d4993
+size 190115840

--- a/firmware/master/1.2.1.2301.ota
+++ b/firmware/master/1.2.1.2301.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cb869e19fce3a13581e0f1170be35a0bcdc780b4db6b804d5e697a1ff0cb598
+size 190248960

--- a/firmware/master/1.3.0.2408.ota
+++ b/firmware/master/1.3.0.2408.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e5685003a670482998189930e0daa07078a87d95cba63b47ca7ee18ef7edd5b
+size 190300160

--- a/firmware/master/1.3.0.2415.ota
+++ b/firmware/master/1.3.0.2415.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b56a498542fc87caaf3434d1878ce7e10d10a7e4fc803d40c1dc9e365ca726d6
+size 190320640

--- a/firmware/master/1.3.0.2422.ota
+++ b/firmware/master/1.3.0.2422.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c578623ab57057b1321e291ec6ae9ce2dc053558be587818857ba6e5732321c5
+size 192768000

--- a/firmware/master/1.3.0.2428.ota
+++ b/firmware/master/1.3.0.2428.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4ebf3e58bf4ffad9472ebcbb90bb8cf4c40da49d227fccd35da3949ba2fd261
+size 192778240

--- a/firmware/master/1.3.0.2433.ota
+++ b/firmware/master/1.3.0.2433.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a7795b26f3f479178d40e80cc98682897ccd3d48b85189777f248fac46bd4b0
+size 192788480

--- a/firmware/master/1.3.0.2439.ota
+++ b/firmware/master/1.3.0.2439.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:227a0208b0e6f2e06544ea31964cc38332946ad8a599598f85af8b7427a3c952
+size 192870400

--- a/firmware/master/1.3.0.2452.ota
+++ b/firmware/master/1.3.0.2452.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:244ddf8e1f0d29b5a9ca3268a2d6149ac3b9d1d076449517bf5f97c01ff690aa
+size 192942080

--- a/firmware/master/1.3.0.2453.ota
+++ b/firmware/master/1.3.0.2453.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a56b6092d06879c7b928c11d2d5bfcbcaeba5d1b715aea0dfe70bce8bb096b7c
+size 192942080

--- a/firmware/master/1.4.0.2615.ota
+++ b/firmware/master/1.4.0.2615.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8a1d75dc38c929c103b898638b4fddc3d45d8651797b52c30d5635f9b0598d4
+size 193351680

--- a/firmware/master/1.4.0.2616.ota
+++ b/firmware/master/1.4.0.2616.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca1b446248c81f4cc57b27aecd71772c44136bd40d1383c4f014c5459372e6a3
+size 193361920

--- a/firmware/master/1.4.0.2617.ota
+++ b/firmware/master/1.4.0.2617.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6f30714fb776f62e180720018ab978ddf3da170f75f54541ba69c9215fc7a37
+size 193351680

--- a/firmware/master/1.4.0.2621.ota
+++ b/firmware/master/1.4.0.2621.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aca0f441a442345e3786814aea7e5a481fb493ef5cf4dbd02e00b18c3312cd81
+size 193413120

--- a/firmware/master/1.4.0.2625.ota
+++ b/firmware/master/1.4.0.2625.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e8876c8f229800d40cad1a1b7174d4fd301a4d2c30ac8839bd846e12e7fb54e
+size 193413120

--- a/firmware/master/1.4.0.2632.ota
+++ b/firmware/master/1.4.0.2632.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bdd3feaaf239af12a4310980256bdf7c4db181b2a08a327a15527d24fa48b90
+size 195317760

--- a/firmware/master/1.4.0.2635.ota
+++ b/firmware/master/1.4.0.2635.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cc8b27526fdc143083ae4b167cafb7fde46ff9476c1f3b90fcc08bac4223a66
+size 195317760

--- a/firmware/master/1.4.0.2638.ota
+++ b/firmware/master/1.4.0.2638.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24428c254c2b0f552b25c1407d04efd09d7da74b3b8efaea4cd1e4210fcb2fee
+size 195338240

--- a/firmware/master/1.4.0.2642.ota
+++ b/firmware/master/1.4.0.2642.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef6135d6af3d506d793253e3f93d958958c3662510e6de2b56bf5a1a3fc6a259
+size 195338240

--- a/firmware/master/1.4.0.2648.ota
+++ b/firmware/master/1.4.0.2648.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e79ca004b4f2ddf63e9003e8d5fb9e93f0cea4a116f82643f08d5bd2bacbccf
+size 195338240

--- a/firmware/master/1.4.0.2652.ota
+++ b/firmware/master/1.4.0.2652.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:260fe921d10aa4a06b4f9ac670a75b30777d84c608d34ce175c14a7b41c58e67
+size 195358720

--- a/firmware/master/1.4.0.2653.ota
+++ b/firmware/master/1.4.0.2653.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfb77bafaece92eec9dbd623b8380123c2d5b526cb132d7eac8dd2aedd7a862b
+size 195348480

--- a/firmware/master/1.4.0.2658.ota
+++ b/firmware/master/1.4.0.2658.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c19a31ba0ef952ffd717e769a3e1141ff1ea37a85268b5fb1725278c558f47
+size 195338240

--- a/firmware/master/1.4.0.2662.ota
+++ b/firmware/master/1.4.0.2662.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:286023b55bb8e5e7236cfb19766b5670c74899f806f328f4cbef480a7cd34796
+size 195348480

--- a/firmware/master/1.4.0.2666.ota
+++ b/firmware/master/1.4.0.2666.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1cb126c3051afc0bee95529b4e594a6323fa697b7fa6b5034334074db4b1cab
+size 195368960

--- a/firmware/master/1.4.0.2671.ota
+++ b/firmware/master/1.4.0.2671.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af725a219e8aabd4a19070ab00ba647fcc34abcd14e0ec1e3a45ca110ebde8f6
+size 195358720

--- a/firmware/master/1.4.0.2673.ota
+++ b/firmware/master/1.4.0.2673.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:574a5e9f9e18b2fbf408edf6d0a43ae87913f1814655a411742632418ef6c6d2
+size 195368960

--- a/firmware/master/1.4.1.2683.ota
+++ b/firmware/master/1.4.1.2683.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abe3d158c620bbbcad6779eda4051f4bcc4d095e5c467344e77faf9311c42a9c
+size 195379200

--- a/firmware/master/1.4.1.2691.ota
+++ b/firmware/master/1.4.1.2691.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81ffa612d14e7732cf2aa845cc5719eff705ab196425dfbb60659768ca190797
+size 195368960

--- a/firmware/master/1.4.1.2693.ota
+++ b/firmware/master/1.4.1.2693.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96e8833a0ff2c217542198c4dc7076fad052450438fb3626e42487357f721ba8
+size 195379200

--- a/firmware/master/1.4.1.2697.ota
+++ b/firmware/master/1.4.1.2697.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:729661387d4e9729ccd2841addb1fd2d1ab84a417b0777154364c6d3e471ecd3
+size 195368960

--- a/firmware/master/1.4.1.2704.ota
+++ b/firmware/master/1.4.1.2704.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46c2b5b166b64871bffbd5ff339004e341d42e573a034086bb26eacc884608d5
+size 195368960

--- a/firmware/master/1.4.1.2708.ota
+++ b/firmware/master/1.4.1.2708.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5ecde0540da28902b5bd5bd5514ccc793d53b83a31539c733856b5abb50cf80
+size 195307520

--- a/firmware/master/1.4.1.2724.ota
+++ b/firmware/master/1.4.1.2724.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0894027666ef593d9d0e49fdeb0a0d57eb3829cdeadf257c0a2b34c892499e8
+size 195993600

--- a/firmware/master/1.4.1.2742.ota
+++ b/firmware/master/1.4.1.2742.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19ebbd404887072dfd9ae47ae28d3f913e41ba6082cfac78701f745875fcadba
+size 193945600

--- a/firmware/master/1.4.1.2746.ota
+++ b/firmware/master/1.4.1.2746.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c513b183041834ee26cef578eca84fda8269e9404781ebd63058393e6afe925
+size 191201280

--- a/firmware/master/1.4.1.2754.ota
+++ b/firmware/master/1.4.1.2754.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39ac36c4bc4be8f720e4c43a83d90d435af1ff05a6f29c0a890d3144b371bca7
+size 191201280

--- a/firmware/master/1.4.1.2761.ota
+++ b/firmware/master/1.4.1.2761.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f18b580deaabf810737ea17635957f0c1ebe3fa613106c1165da1aca97f979c9
+size 191191040

--- a/firmware/master/1.4.1.2767.ota
+++ b/firmware/master/1.4.1.2767.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b038fde06dc8477550f61ab3e01974077484ed8e450606605234313005f93669
+size 190197760

--- a/firmware/master/1.4.1.2773.ota
+++ b/firmware/master/1.4.1.2773.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:656a7ffd60fcf4a00d97f90e164890cd61c9306213907499e30bc5fdb5707e24
+size 190586880

--- a/firmware/master/1.4.1.2778.ota
+++ b/firmware/master/1.4.1.2778.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bea4abc49e3c96211ae1bbf92f2e693817225ae940902775cc009c53b281bec8
+size 190115840

--- a/firmware/master/1.5.0.2904.ota
+++ b/firmware/master/1.5.0.2904.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f5498c3c3ac2e730e7fcf7cfd5d5f83ebaf0d4c4baa7c0ac6c0841e96c76bd
+size 190115840

--- a/firmware/master/1.5.0.2906.ota
+++ b/firmware/master/1.5.0.2906.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce39f8bffafdfc7c4ebbc96108d2f14905cf1e09b93b05061b01a328e7e7c65c
+size 190126080

--- a/firmware/master/1.5.0.2912.ota
+++ b/firmware/master/1.5.0.2912.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1b112c0399cf478ed0aca87fd9953e34eeebbdcb4940968c00c88ddb10bde58
+size 190423040

--- a/firmware/master/1.5.0.2919.ota
+++ b/firmware/master/1.5.0.2919.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33993cb654e6a4eca676a3a386bc2a2d7212c4db6a696d9a2cbd27a936a084f0
+size 190423040

--- a/firmware/master/1.5.0.2924.ota
+++ b/firmware/master/1.5.0.2924.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7294a0fed55be2ba1c55b12e2a16c69137255890391a92f9b782ca31801194d3
+size 190412800

--- a/firmware/master/1.5.0.2928.ota
+++ b/firmware/master/1.5.0.2928.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf43426b2b7ac0b220e55c1f77dd57f56dc5b38ccff08202c26a015c45e21cf3
+size 190423040

--- a/firmware/master/1.5.0.2932.ota
+++ b/firmware/master/1.5.0.2932.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74bcf5e50e10b832f6bc4d3caf98afa9d02baec3ef532ac4f2c8072aee0d3a51
+size 190423040

--- a/firmware/master/1.5.0.2936.ota
+++ b/firmware/master/1.5.0.2936.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65d1855b0dbe09be09a282283750d886f510ffd3b213cc042b62dee9925ddaa4
+size 190382080

--- a/firmware/master/1.5.0.2942.ota
+++ b/firmware/master/1.5.0.2942.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6707004137f349025bb01b12bff0e389778ea6826d472f8cccb9fd8145a02f64
+size 189982720

--- a/firmware/master/1.5.0.2951.ota
+++ b/firmware/master/1.5.0.2951.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd0cf9f5ffdb35031ba5e77ac19ede0ea424f82eb0ab71e34b7671cb97475e1a
+size 190044160

--- a/firmware/master/1.5.0.3101.ota
+++ b/firmware/master/1.5.0.3101.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c556f6a3962c5736c3878e4939b62c48c4baa195bae920c6a7eae537294cf8bf
+size 190095360

--- a/firmware/master/1.6.0.3107.ota
+++ b/firmware/master/1.6.0.3107.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74c05129b9db21c4b3c9b0e23c6f449fcb2a203edeb16d1f7ab156da2b5929e3
+size 190074880

--- a/firmware/master/1.6.0.3111.ota
+++ b/firmware/master/1.6.0.3111.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa20ad049913974518ace2841b7e9c9d685bb4af5b6a02453cce4c638cfbc41c
+size 190095360

--- a/firmware/master/1.6.0.3117.ota
+++ b/firmware/master/1.6.0.3117.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:088c41724e4d32a00a678a9532eb61f44d681f8db6387b066a97135ed148098c
+size 190627840

--- a/firmware/master/1.6.0.3122.ota
+++ b/firmware/master/1.6.0.3122.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3af41dafac40d96b6594b504b92cc40005029296922d2c3495a20dd9e09c6230
+size 190607360

--- a/firmware/master/1.6.0.3126.ota
+++ b/firmware/master/1.6.0.3126.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a254818d9dacf64d00ec55817f07d8188955d4f3633009a585a95c6de532ef0
+size 190627840

--- a/firmware/master/1.6.0.3132.ota
+++ b/firmware/master/1.6.0.3132.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a11085a9f2b636eccab7353d5c5a45e96db39087c1c8f9a2e2ec232a519fcb4
+size 191119360

--- a/firmware/master/1.6.0.3135.ota
+++ b/firmware/master/1.6.0.3135.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76a985a597bf24a76ddaac8e8c8cf119fc69f2c63242ed2c806813248679e1ef
+size 191109120

--- a/firmware/master/1.6.0.3140.ota
+++ b/firmware/master/1.6.0.3140.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6843a33143e1d5d23861cb5ce29ba8be22115256757948fe7bb3ba9064502bae
+size 189798400

--- a/firmware/master/1.6.0.3144.ota
+++ b/firmware/master/1.6.0.3144.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be275f654e00c75138b8c89a3860b302974eca5bd6ad32280013ed80f045503
+size 189808640

--- a/firmware/master/1.6.0.3151.ota
+++ b/firmware/master/1.6.0.3151.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e370538da252fda4fa7cd075ca64e75fe85bc4de6dfea75c656987b077476d8e
+size 189808640

--- a/firmware/master/1.6.0.3156.ota
+++ b/firmware/master/1.6.0.3156.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20b777d915d9e6e5591387236867281fc3037b0437ce47a6e248e514deab4b3f
+size 191221760

--- a/firmware/master/1.6.0.3162.ota
+++ b/firmware/master/1.6.0.3162.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f64e237a6457d2c2436ec37b7e1746b218a8a4c7d1ec6e9ecc455f56010c874
+size 192491520

--- a/firmware/master/1.6.0.3167.ota
+++ b/firmware/master/1.6.0.3167.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:474031d709fbb8b696dd4975fd7fa811d75bb718c5d6b1cdca392633f667a2dd
+size 192481280

--- a/firmware/master/1.6.0.3168.ota
+++ b/firmware/master/1.6.0.3168.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d07f8a71d09b0ecd84884d68eee8df6f1eff9e953da463d116ea905ce47b4d36
+size 192491520

--- a/firmware/master/1.6.0.3172.ota
+++ b/firmware/master/1.6.0.3172.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:032d389cfa9c5d7f73ba5fd088bed72b4faa378cd706bda81e66705fd55a2235
+size 192501760

--- a/firmware/master/1.6.0.3173.ota
+++ b/firmware/master/1.6.0.3173.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891a3972cfb2b96e3f29624ff1c21705288dd4806ed01abda6a77f8609b824a1
+size 192512000

--- a/firmware/master/1.6.0.3174.ota
+++ b/firmware/master/1.6.0.3174.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfd115f22409d0583b128b43ad117f08442b6dc58adf70ece46bb17d0548b140
+size 192512000

--- a/firmware/master/1.6.0.3175.ota
+++ b/firmware/master/1.6.0.3175.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0dc2701aaf106ede871173467b6500226c5ddb6d4e51cf5afabc2dda507be78
+size 192501760

--- a/firmware/master/1.6.0.3180.ota
+++ b/firmware/master/1.6.0.3180.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ad209d77459476dcce9c04cb19eb28ef91fbd07cf1a0ede0a9bf2b7a0d9fc84
+size 192512000

--- a/firmware/master/1.6.0.3185.ota
+++ b/firmware/master/1.6.0.3185.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab60f8994698f70848be0d14683956ec9d72199b29d34859ea2ad4f9e6468291
+size 187535360

--- a/firmware/master/1.6.0.3186.ota
+++ b/firmware/master/1.6.0.3186.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c41b53b061dbe94218877256037a42d2de929eb9419475a0a742899c367e323
+size 187535360

--- a/firmware/master/1.6.0.3190.ota
+++ b/firmware/master/1.6.0.3190.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e9c82cf84b90d826d0e286ea4d0430e1c5caaf777785d873c7fb4386cb278bc
+size 187637760

--- a/firmware/master/1.6.0.3191.ota
+++ b/firmware/master/1.6.0.3191.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a182bed32eb97bcb753ab046f9a04445280c48c963218832fd4ab8e53ca765b
+size 187648000

--- a/firmware/master/1.6.0.3195.ota
+++ b/firmware/master/1.6.0.3195.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7265c8633b49d99f63cbe1299a3caeaf1bc8bd9f96f7adf62e42eb14caa9ea09
+size 187934720

--- a/firmware/master/1.6.0.3198.ota
+++ b/firmware/master/1.6.0.3198.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95f719c706fc0b774d7af98f40ef565d3fcf5325dc0cee41e1beecb30be96e16
+size 187944960

--- a/firmware/master/1.6.0.3199.ota
+++ b/firmware/master/1.6.0.3199.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d258de676a6946160e3b586163a5b28e2b58fcfc33a60abccef5efd44611756
+size 187934720

--- a/firmware/master/1.6.0.3202.ota
+++ b/firmware/master/1.6.0.3202.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e877f48af27c8056348ef98a5e2d710968cc557ce2df2c967d6e7ba846b0dfd
+size 188579840

--- a/firmware/master/1.6.0.3203.ota
+++ b/firmware/master/1.6.0.3203.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:927594edea9ec1cf95a3b57db53d4037c3b9820c37b92fb0a24500ff4c957a27
+size 188590080

--- a/firmware/master/1.6.0.3205.ota
+++ b/firmware/master/1.6.0.3205.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7773bbaf073695d4e88e9548ecb899a81d0542305f5128539592625d289325b2
+size 188590080

--- a/firmware/master/1.6.0.3206.ota
+++ b/firmware/master/1.6.0.3206.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9face4fa406f5f2140cf1b3c025616565ce50f63e2495adb660ad01d7e5d4558
+size 188590080

--- a/firmware/master/1.6.0.3212.ota
+++ b/firmware/master/1.6.0.3212.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6135a25519671b32d5769642a576b0e96085211bea93061ba86946d0b561c749
+size 188764160

--- a/firmware/master/1.6.0.3213.ota
+++ b/firmware/master/1.6.0.3213.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6123cc9a7234b901e401d450edb673fc0befa6aed936de92f70a5ba8b85652a9
+size 188764160

--- a/firmware/master/1.7.0.3302.ota
+++ b/firmware/master/1.7.0.3302.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cbcb58409074a03267b0dbfe81dc3e7ec9a05ec0d31077614ab35bd208d9409
+size 188764160

--- a/firmware/master/1.7.0.3308.ota
+++ b/firmware/master/1.7.0.3308.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:781702f8e17cabf75264d740ecb4508b10326aacd06a78be688015f60c8381ed
+size 188764160

--- a/firmware/master/1.7.0.3314.ota
+++ b/firmware/master/1.7.0.3314.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8b18a3f95f3ef62b6a15ddab50ee60b9318e46cc3ba1641779d9b8230adb27
+size 188743680

--- a/firmware/master/1.7.0.3317.ota
+++ b/firmware/master/1.7.0.3317.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb347fdcfc5099c3794d97a51d24f9b3d87673bae2c36139e22f4f01bc90470
+size 191744000

--- a/firmware/master/1.7.0.3321.ota
+++ b/firmware/master/1.7.0.3321.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:141a403794956f018800ff86636286e1868d948a91901a2841c84ff5876b9c46
+size 191764480

--- a/firmware/master/1.7.0.3327.ota
+++ b/firmware/master/1.7.0.3327.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e1948cdbd2dad71eb66b7cfacd804edb9d7ec58a51684581e7e366767edf997
+size 192696320

--- a/firmware/master/1.7.0.3330.ota
+++ b/firmware/master/1.7.0.3330.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:805c197ecc04c6661d5a6be4b6e615c2b77d31d0f72f09839f1b276cceee2b99
+size 192450560

--- a/firmware/master/1.7.0.3334.ota
+++ b/firmware/master/1.7.0.3334.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41160c615f5e02acf3e664268a74d723b362d50d53fc77296d925100420578f8
+size 193136640

--- a/firmware/master/1.7.0.3337.ota
+++ b/firmware/master/1.7.0.3337.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46b4a9d07120a0defffb67ace1522e13e9b47e2ac1ae72303484ff51d0ad789d
+size 190351360

--- a/firmware/master/1.7.0.3338.ota
+++ b/firmware/master/1.7.0.3338.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3336117147da9f7b477dceabbcef4dced65e83ef45ed575b594709dc051bd866
+size 190341120

--- a/firmware/master/1.7.0.3340.ota
+++ b/firmware/master/1.7.0.3340.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4cb0b2a5a14436156b40a6ffea72f29bf6e05f10f5743b198c34f331be51be3
+size 190361600

--- a/firmware/master/1.7.0.3348.ota
+++ b/firmware/master/1.7.0.3348.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb9d8e60734530f829877191ad9353cddf4e6168b60c631e1a397c1a3d5f75b
+size 190668800

--- a/firmware/master/1.7.0.3349.ota
+++ b/firmware/master/1.7.0.3349.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c20e8f09c2da76647653406144b91caefd3eba330127792d268d8b1853a71ae6
+size 190658560

--- a/firmware/master/1.7.0.3350.ota
+++ b/firmware/master/1.7.0.3350.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f2c890a23aafad8663cdfb5cd25ed20b178c8df0944322b68456df851a6b493
+size 190658560

--- a/firmware/master/1.7.0.3351.ota
+++ b/firmware/master/1.7.0.3351.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0c4984304c7ed459c3d5c31d424c9521d400d73723528e963f5f4e728a7a0a
+size 190658560

--- a/firmware/master/1.7.0.3352.ota
+++ b/firmware/master/1.7.0.3352.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c94118824721aec9319f5f10c7c672d2cf5452784e9ae759b3c4a5aeea0f4621
+size 190668800

--- a/firmware/master/1.7.0.3353.ota
+++ b/firmware/master/1.7.0.3353.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaf4ae81ea4e9faaf0b735caa36c514c614ffc93789d6595ea3e5dda2b21dca7
+size 190781440

--- a/firmware/master/1.7.0.3354.ota
+++ b/firmware/master/1.7.0.3354.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cf89fe7113ebeb9dbc10906189a9b2b3a03dc8754df1f80281474b40074e84b
+size 190812160

--- a/firmware/master/1.7.0.3355.ota
+++ b/firmware/master/1.7.0.3355.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f0d982b2b14f73378309cbd5ab9fc749e341d9bd56d067ce780e28f3d8a3521
+size 190801920

--- a/firmware/master/1.7.0.3356.ota
+++ b/firmware/master/1.7.0.3356.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec20fd9fd46acb091d8d0bf03493bca7ea087a9f869594c60ed51b58e58fb3dc
+size 190791680

--- a/firmware/master/1.7.0.3357.ota
+++ b/firmware/master/1.7.0.3357.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c6912bd1ab47bc701273555ead27980390a09f2b3ef2072baaf550b03d9118
+size 190801920

--- a/firmware/master/1.7.0.3358.ota
+++ b/firmware/master/1.7.0.3358.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:949da97928cfbdee8b4ef6882da3d0cbcfc67203499b0001ccb2c50e06d86ea9
+size 190464000

--- a/firmware/master/1.7.0.3359.ota
+++ b/firmware/master/1.7.0.3359.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75dc98510074083ea928d1498676d47bb79c1479f61435a2a308cddc4145dbbe
+size 190464000

--- a/firmware/master/1.7.0.3360.ota
+++ b/firmware/master/1.7.0.3360.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e75eef1adca75effd3a0d2e910b95c97bfa674fafc7aff451e27e8d312d8bc75
+size 190474240

--- a/firmware/master/1.7.0.3361.ota
+++ b/firmware/master/1.7.0.3361.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d53fa952d046db7956b497cd7c3c93c90f33487390beae02424e1e47b152599f
+size 178319360

--- a/firmware/master/1.7.0.3364.ota
+++ b/firmware/master/1.7.0.3364.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4658308a49e1687a16aaa66ad72d48dfd2af4bb09b077fb4e2c4cabedd72bb9
+size 178186240

--- a/firmware/master/1.7.0.3365.ota
+++ b/firmware/master/1.7.0.3365.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b5b313cbd0ba5fbe8bf89b6d59fb7ea69eb384855e9ff913ace7ad1ee04ffeb
+size 178206720

--- a/firmware/master/1.7.0.3368.ota
+++ b/firmware/master/1.7.0.3368.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:490e574d854856f8e15827f328b99dd276aaf49488cb05a6cde48c3e8738c043
+size 178206720

--- a/firmware/master/1.7.0.3369.ota
+++ b/firmware/master/1.7.0.3369.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e0783d202851ae4b42b3f61f2af6779b2ec309fc029efdc4264c74d8240e13b
+size 178186240

--- a/firmware/master/1.7.0.3371.ota
+++ b/firmware/master/1.7.0.3371.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d69dc34c7bf41f5a7a4cb69e06a9b1e1329ace5287c59e82e3d4842865ff5170
+size 177848320

--- a/firmware/master/1.7.0.3374.ota
+++ b/firmware/master/1.7.0.3374.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fba76766b5e2acb29ce8a4678cf9dd965eb36bfea1cf6f9257a96b97a6b10e57
+size 177838080

--- a/firmware/master/1.7.0.3375.ota
+++ b/firmware/master/1.7.0.3375.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63750cafc6d14ce1971d207f953ab420739a859ff0686d5034472ab5e5ec3631
+size 177848320

--- a/firmware/master/1.7.0.3377.ota
+++ b/firmware/master/1.7.0.3377.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24d679e1fde19339aab4b9364b696bd4367c8acc1144cdf87bc834c4f00182e9
+size 178165760

--- a/firmware/master/1.7.0.3381.ota
+++ b/firmware/master/1.7.0.3381.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7385554c46acd5b1c795a7e4d3f5a31765136acd221aeb17545e5be7b854c59
+size 178083840

--- a/firmware/master/1.7.0.3382.ota
+++ b/firmware/master/1.7.0.3382.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7f680a70722540699eb203927499ce622c47397d8918e82b2bf142aea486071
+size 178073600

--- a/firmware/master/1.7.0.3387.ota
+++ b/firmware/master/1.7.0.3387.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b9c7b25c260314281c703a0a12e55ef1c07e512905347d40343e48a8ebe950
+size 178472960

--- a/firmware/master/1.7.0.3390.ota
+++ b/firmware/master/1.7.0.3390.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfae1cbdc0a6c078cfb975079b691ec92c5fa3e2e60ae95a703bd6794b17c915
+size 178565120

--- a/firmware/master/1.7.0.3398.ota
+++ b/firmware/master/1.7.0.3398.ota
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5f3ba565af29f32d1828eabf0f0caf6bf370fca1034ae52d23f16d54a9ebc2e
+size 178585600


### PR DESCRIPTION
* Added Bluetooth LE protocol documentation and reference code

Added Bluetooth LE protocol documentation and reference code

* A detailed write up on the technical innards of Vector

* Added support for downloading a log

* Added support for downloading a log

* horrible git

* horrible git

* horrible git

* Added initial support for Over the Air updates

* Added update engine code status codes

* Detailed OTA updates, update process and audio processing

* Added a missing step of the boot processes

* Improved the description of the boot.img signature checking

* More boot signing, and https protocol info

* explained how to get files out

* fixed markup

* fixed some missing steps

* typo

* Revised and expanded writeups

Further details on the boot signature checking
More settings and diagnostic logging
Various typo fixes

* Decompiled aboot

I've decompiled aboot with ghidra, and attempted to figure out the flow of the code

* Added the secondary bootloader

Added a decompiled version of the secondary bootloader
Add more of the missing strings to aboot decompile

* Added RPM

* added readme

* typos

* better explaination of where the buried treasure should have been

* added some missing files

* clarified the check for modification to the device structure

* Update README.md

* Expanded description of the AI and high level AI

Added tables of the emotion modifiers, and the behaviors names that Vector is currently doing
Added a description of the behavior system priorities
Expanded info on custom objects
Moved the sound input chapter
More information on motion sensing
More information on the animation trigger names and how they map to animation files

* The 1.7 firmware

* Updating from master

* Added OTA files from staging stream

* Delete ABOOT-orig.c

* Delete ABOOT.c

* Delete RPM.orig.c

* Delete rampost.orig.c

* Delete TZ.orig.c

* Delete SBL1.orig.c

* Delete SBL1.c

* Added OTA files from the beta stream

* Added OTA files from rc-dev stream

* Delete 1.6.4.1106.ota

The file was mistakenly checked in

* Delete 1.6.4.1106.ota

File was accidentally checked in

* Added rc stream of OTA files

* Added OTA files from master stream

Co-authored-by: Randall Maas <randym@randym.name>